### PR TITLE
Update ALE link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 A python interface for the Arcade Learning Environment
 
 This provides a python library to interface with the arcade learning environment that can be found here:
-http://www.arcadelearningenvironment.org/
+https://github.com/mgbellemare/Arcade-Learning-Environment
+
 
 This library hooks into the shared object file for the arcade learning environment and bypasses using the slower FIFO interface.
 It is designed to be fast. Example code is provided that demonstrates an agent that can be controlled from the keyboard.


### PR DESCRIPTION
The site http://www.arcadelearningenvironment.org/ is dead at the time of this commit. Update readme with link to git repository, which was last updated six days ago.